### PR TITLE
Update cli version to avoid deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "colors": "*",
     "callsite": "*",
     "stack-trace": "*",
-    "cli": "0.6.5",
+    "cli": "0.6.6",
     "daemon": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
With cli 0.6.5 I get the following deprecation warnings:

```
Connecting ...  -util.print: Use console.log instead
Connecting ...  \util.print: Use console.log instead
Connecting ...  |util.print: Use console.log instead
Connecting ...  /util.print: Use console.log instead
Connecting ...  -util.print: Use console.log instead
Connecting ...  \util.print: Use console.log instead
Connecting ...  |util.print: Use console.log instead
Connecting ...  /util.print: Use console.log instead
Connecting ...  -util.print: Use console.log instead
Connecting ...  \util.print: Use console.log instead
Connecting ...  |util.print: Use console.log instead
Connecting ...  /util.print: Use console.log instead
Connecting ...  -util.print: Use console.log instead
Connecting ...  \util.print: Use console.log instead
Connecting ...  |util.print: Use console.log instead
Connecting ...  /util.print: Use console.log instead
Connecting ...  -util.print: Use console.log instead
```

By setting cli version to 0.6.6 these warnings dissappear.