### PR TITLE
Passing full headers through to callback in amqp resources listenOnRe…

### DIFF
--- a/amqp/amqp-resources.js
+++ b/amqp/amqp-resources.js
@@ -109,7 +109,8 @@ function setupResourceHandler(handlers) {
                 }
                 handler({
                     verb:verb,
-                    resource:resource
+                    resource:resource,
+					headers: request.headers
                 }, message, function(response, headers) {
                     if (typeof headers === 'undefined') {
                         headers = {};

--- a/amqp/amqp-resources.js
+++ b/amqp/amqp-resources.js
@@ -63,7 +63,7 @@ module.exports = function(queues) {
             for(var k in u.query) head[k]= u.query[k];
 
             event.headers = head;
-            console.dir(event.headers);
+            event.headers._QUERY = u.query;
 
             module.queues.send(queue, event);
         },
@@ -110,7 +110,7 @@ function setupResourceHandler(handlers) {
                 handler({
                     verb:verb,
                     resource:resource,
-					headers: request.headers
+					query: request.headers._QUERY
                 }, message, function(response, headers) {
                     if (typeof headers === 'undefined') {
                         headers = {};

--- a/amqp/amqp-resources.js
+++ b/amqp/amqp-resources.js
@@ -110,7 +110,7 @@ function setupResourceHandler(handlers) {
                 handler({
                     verb:verb,
                     resource:resource,
-					query: request.headers._QUERY
+                    query: request.headers._QUERY
                 }, message, function(response, headers) {
                     if (typeof headers === 'undefined') {
                         headers = {};


### PR DESCRIPTION
…source, which previously dropped query parameters (and all the headers in fact) before they reached the callback.

This allows a url of the form muon://organisation/?organisation=sky to be correctly processed in the callback.

    muon.resource.onQuery("/", "Get the organisation", function(event, data, respond) {
        console.log(event.headers);
        respond({nod: event.headers.organisation });
    });

Responds with {nod: "sky"};